### PR TITLE
Allow attributes to appear before src in img regexp

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -40,7 +40,7 @@ class listener implements EventSubscriberInterface
 				foreach ($matches[1] as $url)
 				{
 					// Don't rewrite requests for this site
-					if (stripos($url, SITEDOMAIN) !== false)
+					if (stripos($url, SITE_DOMAIN) !== false)
 					{
 						$object[$key] = preg_replace('#http:#', 'https:', $object[$key]);
 					}

--- a/event/listener.php
+++ b/event/listener.php
@@ -35,7 +35,7 @@ class listener implements EventSubscriberInterface
 	{
 		if (!empty($object[$key]))
 		{
-			if (preg_match_all('#<img src="(http://[^"]+)" [^/]+ />#', $object[$key], $matches))
+			if (preg_match_all('#<img[^/]* src="(http://[^"]+)" [^/]+ />#', $object[$key], $matches))
 			{
 				foreach ($matches[1] as $url)
 				{

--- a/event/listener.php
+++ b/event/listener.php
@@ -47,7 +47,7 @@ class listener implements EventSubscriberInterface
 					else
 					{
 						$digest = hash_hmac('sha1', $url, CAMO_KEY);
-						$object[$key] = str_replace($url, 'https://' . ASSETS_DOMAIN . '/' . $digest . '/' . bin2hex($url), $object[$key]);
+						$object[$key] = str_replace('src="' . $url, 'src="https://' . ASSETS_DOMAIN . '/' . $digest . '/' . bin2hex($url), $object[$key]);
 					}
 				}
 			}


### PR DESCRIPTION
phpbb_get_avatar in includes/functions.php outputs code in the format:

`<img class="avatar" src="..." ... />`

which doesn't get picked up by the regular expression in this plug-in. The commit I've made will allow attributes to be included either before or after the src attribute.