### PR TITLE
bikeshedding/latest revision compatibility with older versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "Rewrites image URLs to point to a cammo image proxy.",
 	"homepage": "https://www.phpbb.com/",
-	"version": "1.0.2",
+	"version": "1.0.2.1",
 	"time": "2013-09-06 14:22:00",
 	"license": "GPL-2.0",
 	"authors": [
@@ -34,7 +34,7 @@
 	"extra": {
 		"display-name": "phpBB Camo SSL Image Proxy Extension",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.1.*@dev"
+			"phpbb/phpbb": ">=3.2.*,<3.3.0@dev"
 		}
 	}
 }


### PR DESCRIPTION
If I am correct, `09392c21ae6065e66ae6758dbcd4c663c1b98a48` is a patch made to bring compatibility of camosslimageproxy to phpBB 3.2. It is unsure if this plugin is compatible with phpBB 3.1. And we must assume that this plugin is not compatible with newer versions after phpBB 3.2.